### PR TITLE
Feat: #70/목록 페이지에 크레딧섹션 배치 및 현재 크레딧 표시 구현

### DIFF
--- a/src/pages/listPage/CreditSection.jsx
+++ b/src/pages/listPage/CreditSection.jsx
@@ -1,6 +1,8 @@
+import { getCredits } from '../../utils/CreditStorage';
+
 export default function CreditSection() {
   return (
-    <div className="h-[87px] pl-[70px] pr-[78px] border border-[#C1BECA] rounded-lg flex items-center justify-between w-full max-w-[1200px] min-w-[327px] pc:h-[131px] tablet:h-[131px]">
+    <div className="h-[87px] pl-[70px] pr-[78px] border border-[#C1BECA] rounded-lg flex items-center justify-between w-full max-w-[1200px] min-w-[327px] pc:h-[131px] tablet:h-[131px] mt-[16px] mb-[40px] tablet:mt-[0] tablet:mb-[64px] pc:my-[50px]">
       <div className="flex flex-col items-start">
         <p className="ml-[7px] font-pretendard font-normal text-[#9A999F] text-[12px] pc:text-[16px] tablet:text-[16px]">
           내 크레딧
@@ -8,7 +10,7 @@ export default function CreditSection() {
         <div className="flex items-center justify-between">
           <div className="w-[30px] h-[30px] bg-[url(@/assets/icons/credit.svg)] bg-contain bg-no-repeat bg-center" />
           <p className="font-pretendard font-bold text-[#DEDEE0] text-[20px] pc:text-[24px] tablet:text-[24px]">
-            36,000
+            {getCredits()}
           </p>
         </div>
       </div>

--- a/src/pages/listPage/ListPage.jsx
+++ b/src/pages/listPage/ListPage.jsx
@@ -1,8 +1,10 @@
 import DonationsList from '@/pages/listPage/DonationsList';
+import CreditSection from './CreditSection';
 
 function ListPage() {
   return (
-    <div class="bg-midnightBlack">
+    <div class="bg-midnightBlack flex flex-col items-center">
+      <CreditSection />
       <DonationsList />
     </div>
   );

--- a/src/utils/CreditStorage.js
+++ b/src/utils/CreditStorage.js
@@ -5,7 +5,8 @@ export const initCredits = (initialCreditValue = 50) => {
 };
 
 export const getCredits = () => {
-  return parseInt(localStorage.getItem('credits'), 10) || 0;
+  const credits = parseInt(localStorage.getItem('credits'), 10) || 0;
+  return credits.toLocaleString();
 };
 
 export const rechgCredits = (amount) => {


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number
#70 
<!--- ex) #이슈번호, #이슈번호 -->

<br/>
<br/>

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
<!--- 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 목록 페이지에 크레딧섹션 배치
- 크레딧섹션이 CreditStorage의 현재 크레딧을 가져와 표시하도록 함
<br/>
<br/>

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>
<br/>

## 📸스크린샷 (선택)
<!--- 없을 시 해당 목차 삭제 바람 -->

![image](https://github.com/user-attachments/assets/cc86648d-7911-4534-b443-9343b23931f8)


<br/>
<br/>


## 💬 공유사항
<!--- 차후 작업 시 염두해야할 부분 -->
- 크레딧 섹션 위쪽으로 responsive 마진 설정해 놓았으니 nav 배치하실때 마진 아래쪽으로는 안 주셔도 됩니다.
- 섹션의 배경색은 임시로 넣어둔 것으로 추후에 목록 페이지 자체에 배경디자인이 적용되면 해당 임시 배경색은 제거해야 합니다.
- DonationsList 섹션의 responsive를 재조정해야 할 거 같습니다. (아래 캡쳐화면 참조)

PC1
![image](https://github.com/user-attachments/assets/297a3c92-52c3-46bb-b326-e7d452bf5274)
좌우 버튼으로 인한 스크롤과 다른 섹션과의 정렬 어긋남 발생

PC2
![image](https://github.com/user-attachments/assets/bd5dd850-f3ec-40eb-a397-a98e37d9fc91)
좌우 버튼으로 인한 스크롤과 다른 섹션과의 정렬 어긋남 발생

Tablet
![image](https://github.com/user-attachments/assets/154cdc0d-cfd7-45fb-86c1-ced6fedfc4cf)
왼쪽 마진, 스크롤 발생

Mobile1
![image](https://github.com/user-attachments/assets/ff515043-1b4b-4000-add7-c0c0a46e91c7)
여유있는 넓이에서 이상 없으나

Mobile2
![image](https://github.com/user-attachments/assets/217bb269-8bca-4bd8-91af-bf1aee68eb3d)
왼쪽 마진과 스크롤 발생

<br/>
<br/>


## 📚 코드 이해에 필요한(혹은 본인이 이해하는데 사용한) 레퍼런스 목록
<!--- 없을 시 해당 목차 삭제 바람 -->


<br/>
<br/>