### PR TITLE
refactor: #118/DonationsList의 데이터 불러오는 방식 변경

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react';
+// import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import '@/index.css';
 import App from './App.jsx';
 
 createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <App />
-  </StrictMode>
+  // <StrictMode>
+  <App />
+  // </StrictMode>
 );

--- a/src/pages/listPage/ListPage.jsx
+++ b/src/pages/listPage/ListPage.jsx
@@ -56,7 +56,7 @@ function ListPage() {
   }[modalStep];
 
   return (
-    <div className="min-h-screen bg-midnightBlack px-6 pc:px-0 relative">
+    <div className="px-6 pc:px-0 relative">
       <img
         src={leftTopGradient}
         alt="leftTopGradient"

--- a/src/pages/notFoundPage/NotFoundPage.jsx
+++ b/src/pages/notFoundPage/NotFoundPage.jsx
@@ -3,7 +3,7 @@ import PrimaryButton from '@/components/PrimaryButton';
 
 function NotFoundPage() {
   return (
-    <div className="min-h-screen flex flex-col justify-center items-center bg-midnightBlack font-pretendard">
+    <div className="min-h-screen flex flex-col justify-center items-center font-pretendard">
       <div className="font-bold text-[50px] bg-gradient-to-r from-coralRed to-pinkPunch bg-clip-text text-transparent">
         404
       </div>


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#118 

<br/>
<br/>

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
<!--- 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
### PC 사이즈 화면에서 이전 페이지 데이터를 불러올 때의 방식 변경
이전에는 각 페이지의 데이터를 캐싱해서 이전 버튼을 눌렀을 때 현재 페이지의 데이터를 삭제하는 방식으로 이전 페이지의 데이터를 보여줬다.

그런데 이전 페이지의 값을 불러올 때만 캐싱을 사용하는 것이 불필요하다고 판단했다.

그래서 다음 버튼을 눌렀을 때 해당 페이지의 cursor 값(다음 버튼을 눌렀기 때문에 이전 페이지의 corsor 값)을 배열에 저장하고, 이전 버튼을 눌렀을 때 해당 배열에서 이전 페이지의 cursor 값을 찾아 해당 cursor 값을 query로 추가하여 get 리퀘스트 요청을 보내는 방식으로 변경하였다.


### 불필요하게 배경색 지정한 부분 삭제
body에 midnightBlack으로 배경색이 들어가게 되어서 ListPage와 NotFoundPage에 지정한 배경색을 삭제하였다.


<br/>
<br/>

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>
<br/>
