### PR TITLE
feat: #145/후원 모달에서 put 리퀘스트 보낸 후 바로 리렌더링

### DIFF
--- a/src/pages/listPage/ListPage.jsx
+++ b/src/pages/listPage/ListPage.jsx
@@ -71,7 +71,10 @@ function ListPage() {
         onCreditShortageClick={() => openModal('creditNotEnough')}
         credits={credits}
       />
-      <DonationsList onDonationClick={(item) => openModal('donation', item)} />
+      <DonationsList
+        onDonationClick={(item) => openModal('donation', item)}
+        credits={credits}
+      />
       <MonthlyChartSection
         onClickVote={() => {
           openModal('vote');

--- a/src/pages/listPage/donation/DonationsList.jsx
+++ b/src/pages/listPage/donation/DonationsList.jsx
@@ -85,7 +85,6 @@ function DonationsList({ onDonationClick, credits }) {
   }, [credits]);
 
   useEffect(() => {
-    console.log(prevCreditsRef.current > credits);
     if (prevCreditsRef.current > credits) {
       if (isPC) {
         handleLoad({ cursor: cursorArr[cursorArr.length - 1] });

--- a/src/pages/listPage/donation/DonationsList.jsx
+++ b/src/pages/listPage/donation/DonationsList.jsx
@@ -6,7 +6,7 @@ import nextIcon from '@/assets/icons/nextIcon.svg';
 
 const MAXIMUL_VIEW_DONATIONS = 4;
 
-function DonationsList({ onDonationClick }) {
+function DonationsList({ onDonationClick, credits }) {
   const [items, setItems] = useState([]);
   const [cursor, setCursor] = useState(0);
   const [cursorArr, setCursorArr] = useState([0]);
@@ -14,6 +14,7 @@ function DonationsList({ onDonationClick }) {
   const [isError, setIsError] = useState(false);
   const [isPC, setIsPC] = useState(window.innerWidth >= 1200);
   const observerRef = useRef(null);
+  const prevCreditsRef = useRef(credits);
 
   const handleLoad = async (query) => {
     setIsLoading(true);
@@ -75,6 +76,25 @@ function DonationsList({ onDonationClick }) {
     if (observerRef.current) observer.observe(observerRef.current);
     return () => observer.disconnect();
   }, [cursor, isPC]);
+
+  // 크레딧 값이 감소했을 시 GET Request
+  useEffect(() => {
+    setTimeout(() => {
+      prevCreditsRef.current = credits;
+    }, 0);
+  }, [credits]);
+
+  useEffect(() => {
+    console.log(prevCreditsRef.current > credits);
+    if (prevCreditsRef.current > credits) {
+      if (isPC) {
+        handleLoad({ cursor: cursorArr[cursorArr.length - 1] });
+      } else {
+        setItems([]);
+        handleLoad({ cursor: 0 });
+      }
+    }
+  }, [credits]);
 
   return (
     <div className="flex flex-col gap-4 tablet:gap-6 pc:gap-8 font-pretendard text-softWhite">


### PR DESCRIPTION
<!--- Pull Request title = 커밋 메시지와 동일/ 해당 이슈를 close 하지 않을 경우, footer #이슈 번호 제외  -->

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#145 

<br/>
<br/>

## 📝 요약(Summary)
<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. -->
<!--- 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 후원 모달에서 PUT 리퀘스트 보낸 후 업데이트된 서버 데이터를 바로 화면에 반영
 localStorage에 저장된 크레딧 개수의 변동을 감지하여, 크레딧 개수가 감소되었을 때 GET 리퀘스트를 보내 업데이트된 데이터로 리렌더링

<br/>
<br/>

## 🛠️ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>
<br/>


## 📚 코드 이해에 필요한(혹은 본인이 이해하는데 사용한) 레퍼런스 목록
<!--- 없을 시 해당 목차 삭제 바람 -->
```
useEffect(() => {
    setTimeout(() => {
      prevCreditsRef.current = credits;
    }, 0);
  }, [credits]);
```
useRef의 값은 렌더링 후에 갱신되기 때문에 prevCreditsRef.current와 credits를 비교할 때 두 값이 같은 상황이 발생할 수 있다.
이를 해결하기 위해 setTimeout을 사용하여 렌더링이 완료된 후 prevCreditsRef.current에 credits 값을 할당하도록 했다.

<br/>
<br/>